### PR TITLE
created a specific page for only one map

### DIFF
--- a/front-end/src/pages/map/crops.tsx
+++ b/front-end/src/pages/map/crops.tsx
@@ -1,0 +1,9 @@
+import MapCropsMap from 'containers/sections/agricultural-risk/map-crops';
+
+const Crops: React.FC = () => (
+  <div>
+    <MapCropsMap defaultActiveLayerId={'crops'} allowZoom={true} />
+  </div>
+);
+
+export default Crops;


### PR DESCRIPTION
The `yarn export` will create a folder, so it will be accessible following the route `https://domain/map/crop` or `https://domain/map/crops.html`